### PR TITLE
ip update. add keys. minor fixes

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -25,11 +25,11 @@ all:
           wg0_ip_address: "10.14.47.3"
           hostapd_ssid: second-case
           hostapd_wpa_password: Aalborg9000Robotlab
-        10.14.47.4:
+        10.14.47.5:
           ansible_user: pi
           ansible_become: yes
           ansible_ssh_common_args: -F ssh_config
           ansible_python_interpreter: /usr/bin/python3
-          wg0_ip_address: "10.14.47.4"
+          wg0_ip_address: "10.14.47.5"
           hostapd_ssid: grundfos-case
           hostapd_wpa_password: Aalborg9000Robotlab

--- a/ansible/roles/api/files/api.service
+++ b/ansible/roles/api/files/api.service
@@ -2,6 +2,8 @@
 Description=IDL api for various tasks
 
 [Service]
+Restart=always
+RestartSec=10s
 ExecStart=/home/pi/api
 DynamicUser=yes
 

--- a/ansible/roles/users/tasks/main.yml
+++ b/ansible/roles/users/tasks/main.yml
@@ -6,3 +6,9 @@
   loop:
     - https://github.com/fasmide.keys
     - https://github.com/hjalte33.keys
+    - https://github.com/martinjensen37.keys
+
+- name: add development pc public key to user {{ ansible_user }}
+  authorized_key:
+    key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDTO/V8pJbEq2tQ9ETOnK/LoJ7ZKWUzvPBOyjl2RoD/Zq9eqbL60g/0JSrm6ru/Ic0+mOb1OviJWbDmshJYGZ2djPlEIbMf6gaB1bgiL+VVeCKuTrncBki5EuEs3uBo66LqS1jX/RtRB5LKcD7VGknRdnlElsZ6LLqfH0x8WoQPyy7PV4fbb0/7yMTehf9R2CQDrqepOQgDJWn31w/llJ9yI1tyvYZgroyFPRi6AuzjdVpzSslx4Ob0qoRIV7mDbux6G9LLlOGdGoi4IewASSK7r4A50htgMa+22pm1l/LeOdp4iw74tI8ogfQgcFrXbmoDea2sf7Z+r/VDvm60D8Falelan/fDjtbC+btOiK3FEwdtAtO1ukrJp1jDsfuX6fyA2SBdpnWbpJzH4lzRLDJbxhEffTh0yX0DgmeanKj2G1Nhy233URJIQ62kPK7nlut8xCHo4cNwc5zd0xV86fxhfcTaIFcm8Eklq67erDNgcrgnF/nw7MQATQgTmEaZmk8= idluser@idl-development"
+    user: "{{ ansible_user }}"

--- a/ansible/roles/webgateway/files/traefik_sites.yml
+++ b/ansible/roles/webgateway/files/traefik_sites.yml
@@ -68,11 +68,11 @@ http:
     grafana-grundfos:
       loadBalancer:
         servers:
-          - url: "http://10.14.47.4:3000/"
+          - url: "http://10.14.47.5:3000/"
     api-grundfos:
       loadBalancer:
         servers:
-          - url: "http://10.14.47.4:9090/"
+          - url: "http://10.14.47.5:9090/"
 
   middlewares:
     httpsredirect:

--- a/idlversion
+++ b/idlversion
@@ -8,7 +8,7 @@ TYPE=$(basename $(pwd))
 
 # Access VPN network using artifacts normally used by ansible
 CURLCMD=`echo -n "curl --fail -s ${TARGET}/db/${TYPE} | jq .\"version\""`
-CURRENTVERSION=`ssh -F ../ssh_config -S /tmp/.idl-%C -o "ControlMaster=auto" -o "ControlPersist=1h" metric-log01 ${CURLCMD}`
+CURRENTVERSION=`ssh -F ../ssh_config -S /tmp/.idl-%C -o "ControlMaster=auto" -o "ControlPersist=1m" metric-log01 ${CURLCMD}`
 
 # Fetch current version
 NEXTVERSION=$((CURRENTVERSION+1))


### PR DESCRIPTION
added some keys
updates an ip address that changed. It was not necessary, but now there's no way back now... the previous ip 10.13.37.4 is now up for grabs. 
auto restart for the api 
idl upload script changed controlPersist to 1 minute instead of one hour so you don't get locked up to one device for too long.  